### PR TITLE
Changed logback and disabled tomcat for client formatting #47

### DIFF
--- a/client/src/main/java/com/chattycathy/client/ClientApplication.java
+++ b/client/src/main/java/com/chattycathy/client/ClientApplication.java
@@ -38,8 +38,9 @@ public class ClientApplication implements CommandLineRunner {
 	 * @param args incoming main method arguments
 	 */
 	@Override
-	public void run(String... args) {
+	public void run(String... args) throws InterruptedException {
 		sessionHandler.setUser(new User(scanner));
 		new ServerInputHandler(this).connectToServer();
+		Thread.currentThread().join(); // Ensures the main thread doesn't close without the run thread completing
 	}
 }

--- a/client/src/main/resources/application.properties
+++ b/client/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=client
 server.port=8081
 spring.main.banner-mode=off
+spring.main.web-application-type=none

--- a/client/src/main/resources/logback-spring.xml
+++ b/client/src/main/resources/logback-spring.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="Console"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>
+                %highlight([%level]) %msg%n
+            </Pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="Console" />
+    </root>
+</configuration>


### PR DESCRIPTION
I have changed the logback formatting and removed tomcat to give the users an easier view, below is the new output with a wide array of example logs:
![image](https://github.com/user-attachments/assets/6421e93e-0799-4088-b9c2-95da00df2254)

Closes #47 
